### PR TITLE
Custom version name format

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 22 20:58:34 JST 2015
+#Tue Sep 06 12:12:44 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -6,6 +6,7 @@ import groovy.json.internal.LazyMap
 
 class AndroidAutoVersionExtension {
     File versionFile
+    Closure<String> versionFormatter
     private Version version
 
     def getVersion() {
@@ -23,7 +24,7 @@ class AndroidAutoVersionExtension {
     private def sanityCheck() {
         if (!version) {
             LazyMap map = new JsonSlurper().parseText(versionFile.text);
-            version = new Version(map)
+            version = new Version(map, versionFormatter)
         }
     }
 }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -90,7 +90,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             git.commit(message: "Update version")
 
             // Tag
-            git.tag.add(name: "v${newVersion.toString()}")
+            git.tag.add(name: "${newVersion.toString()}")
         }
     }
 

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -7,23 +7,29 @@ class Version {
     int patch = 0;
     int minor = 0;
     int major = 0;
+    Closure<String> formatter;
 
     Version(Version source) {
         buildNumber = source.buildNumber;
         patch = source.patch;
         minor = source.minor;
         major = source.major;
+        formatter = source.formatter;
     }
 
-    Version(LazyMap source) {
+    Version(LazyMap source, Closure<String> formatter) {
         buildNumber = source.buildNumber;
         patch = source.patch;
         minor = source.minor;
         major = source.major;
+        this.formatter = formatter;
     }
 
     String versionName() {
-        return "${major}.${minor}.${patch}";
+        if (formatter == null) {
+            return "${major}.${minor}.${patch}"
+        }
+        return formatter.call(major, minor, patch, buildNumber)
     }
 
     int versionCode() {
@@ -32,6 +38,6 @@ class Version {
 
     @Override
     String toString() {
-        return "${major}.${minor}.${patch}.${buildNumber}";
+        return versionName();
     }
 }


### PR DESCRIPTION
Allow users to specify a custom format for version name. Maybe something like:

```
androidAutoVersion {
  versionFile file('/path/to/version/file')
  versionNameFormat "$major.$minor.$patch.$buildNumber"
}
```
