### PR TITLE
Beta support

### DIFF
--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -1,12 +1,12 @@
 package com.github.alexfu
 
-import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.json.internal.LazyMap
 
 class AndroidAutoVersionExtension {
     File versionFile
     Closure<String> versionFormatter
+    String betaReleaseTask
     private Version version
 
     def getVersion() {
@@ -16,9 +16,7 @@ class AndroidAutoVersionExtension {
 
     def saveVersion(Version version) {
         this.version = version;
-
-        def contents = new JsonBuilder(version).toPrettyString();
-        versionFile.write(contents);
+        versionFile.write(version.toJson());
     }
 
     private def sanityCheck() {

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -2,11 +2,15 @@ package com.github.alexfu
 
 import groovy.json.JsonSlurper
 import groovy.json.internal.LazyMap
+import org.gradle.api.Nullable
 
 class AndroidAutoVersionExtension {
     File versionFile
-    Closure<String> versionFormatter
-    String betaReleaseTask
+    String releaseTask
+
+    @Nullable Closure<String> versionFormatter
+    @Nullable String betaReleaseTask
+
     private Version version
 
     def getVersion() {

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -1,7 +1,6 @@
 package com.github.alexfu
 
 import org.ajoberstar.grgit.Grgit
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -84,7 +83,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             def git = Grgit.open(project.rootDir)
 
             // Add changes
-            git.add(update: true, patterns: ["config/version"])
+            git.add(update: true, patterns: [extension.versionFile.path])
 
             // Commit
             git.commit(message: "Update version")

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -3,74 +3,96 @@ package com.github.alexfu
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 class AndroidAutoVersionPlugin implements Plugin<Project> {
     private enum VersionType {
-        MAJOR, MINOR, PATCH
+        MAJOR("Major"), MINOR("Minor"), PATCH("Patch")
+        static def all() {
+            return [MAJOR, MINOR, PATCH]
+        }
+
+        private final String name;
+
+        private VersionType(String name) {
+            this.name = name;
+        }
     }
+
+    private enum VersionFlavor {
+        RELEASE("Release"), BETA("Beta")
+        static def all() {
+            return [RELEASE, BETA]
+        }
+
+        private final String name;
+
+        private VersionFlavor(String name) {
+            this.name = name;
+        }
+    }
+
+    private AndroidAutoVersionExtension extension
 
     @Override
     void apply(Project project) {
         project.extensions.create("androidAutoVersion", AndroidAutoVersionExtension)
 
         project.afterEvaluate {
-            applyVersion(project, project.androidAutoVersion.getVersion())
+            extension = project.androidAutoVersion
+            applyVersion(project, extension.getVersion())
+            makeReleaseTasks(project)
         }
+    }
 
-        // Create prepare tasks
-        def majorPrepTask = makePrepareTask(project, VersionType.MAJOR);
-        def minorPrepTask = makePrepareTask(project, VersionType.MINOR);
-        def patchPrepTask = makePrepareTask(project, VersionType.PATCH);
+    private def makeReleaseTasks(Project project) {
+        def types = VersionType.all()
+        def flavors = VersionFlavor.all()
 
-        // Set up task ordering
-        project.tasks.whenTaskAdded { task ->
-            if (task.name.equals("assembleRelease")) {
-                task.mustRunAfter(majorPrepTask, minorPrepTask, patchPrepTask)
+        def tasks = []
+        for (def flavor in flavors) {
+            for (def type in types) {
+                tasks.add(makeReleaseTask(project, type, flavor))
             }
         }
 
-        // Create release tasks
-        makeReleaseTask(project, VersionType.MAJOR, majorPrepTask)
-        makeReleaseTask(project, VersionType.MINOR, minorPrepTask)
-        makeReleaseTask(project, VersionType.PATCH, patchPrepTask)
+        return tasks
     }
 
-    private def makeReleaseTask(Project project, VersionType type, Task prepTask) {
-        def name;
-        switch (type) {
-            case VersionType.MAJOR:
-                name = "releaseMajor";
-                break;
-            case VersionType.MINOR:
-                name = "releaseMinor";
-                break;
-            case VersionType.PATCH:
-                name = "releasePatch";
-                break;
+    private def makeReleaseTask(Project project, VersionType type, VersionFlavor flavor) {
+        def name = "release"
+        if (flavor == VersionFlavor.BETA) {
+            name += flavor.name
+        }
+        name += type.name
+
+        def prepTask = makePrepareTask(project, type, flavor)
+        def dependencies = [prepTask.name]
+
+        if (flavor == VersionFlavor.RELEASE) {
+            def releaseTask = "assembleRelease"
+            dependencies.add(releaseTask)
+            def task = project.getTasks().getByName("assembleRelease")
+            task.mustRunAfter(prepTask)
+        }
+        if (flavor == VersionFlavor.BETA) {
+            def betaReleaseTask = extension.betaReleaseTask
+            dependencies.add(betaReleaseTask)
+            def task = project.getTasks().getByName(betaReleaseTask)
+            task.mustRunAfter(prepTask)
         }
 
-        return project.task(name, {
-            dependsOn prepTask.name, "assembleRelease"
+        project.task(name, {
+            dependsOn dependencies
         })
     }
 
-    private def makePrepareTask(Project project, VersionType type) {
-        def name;
-        switch (type) {
-            case VersionType.MAJOR:
-                name = "prepareMajorRelease";
-                break;
-            case VersionType.MINOR:
-                name = "prepareMinorRelease";
-                break;
-            case VersionType.PATCH:
-                name = "preparePatchRelease";
-                break;
+    private def makePrepareTask(Project project, VersionType type, VersionFlavor flavor) {
+        def name = "prepare"
+        if (flavor == VersionFlavor.BETA) {
+            name += flavor.name
         }
-
+        name += type.name
         return project.task(name) << {
-            def extension = (AndroidAutoVersionExtension) project.androidAutoVersion;
             def version = extension.getVersion();
             def newVersion = updateVersion(version, type);
 
@@ -83,13 +105,19 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             def git = Grgit.open(project.rootDir)
 
             // Add changes
-            git.add(update: true, patterns: [extension.versionFile.path])
+            def currentDir = new File(new File("").absolutePath) // File must use absolute path
+            def versionFilePath = currentDir.toPath().relativize(extension.versionFile.toPath()).toString()
+            git.add(update: true, patterns: [versionFilePath])
 
             // Commit
             git.commit(message: "Update version")
 
             // Tag
-            git.tag.add(name: "${newVersion.toString()}")
+            if (flavor == VersionFlavor.BETA) {
+                git.tag.add(name: "${newVersion.betaVersionName()}")
+            } else {
+                git.tag.add(name: "${newVersion.versionName()}")
+            }
         }
     }
 

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -6,9 +6,9 @@ import org.gradle.api.Project
 
 class AndroidAutoVersionPlugin implements Plugin<Project> {
     enum VersionType {
-        MAJOR("Major"), MINOR("Minor"), PATCH("Patch")
+        MAJOR("Major"), MINOR("Minor"), PATCH("Patch"), NONE("")
         static def all() {
-            return [MAJOR, MINOR, PATCH]
+            return [MAJOR, MINOR, PATCH, NONE]
         }
 
         private final String name;

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -110,7 +110,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             extension.saveVersion(version)
 
             // Apply to all variants
-            applyVersion(project)
+            applyVersion(project, flavor)
 
             def git = Grgit.open(project.rootDir)
 
@@ -123,18 +123,14 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             git.commit(message: "Update version")
 
             // Tag
-            if (flavor == VersionFlavor.BETA) {
-                git.tag.add(name: "${version.betaVersionName()}")
-            } else {
-                git.tag.add(name: "${version.versionName()}")
-            }
+            git.tag.add(name: "${version.versionNameForFlavor(flavor)}")
         }
     }
 
-    private def applyVersion(Project project) {
+    private def applyVersion(Project project, VersionFlavor flavor = VersionFlavor.RELEASE) {
         project.android.applicationVariants.all { variant ->
             def versionCode = extension.getVersion().versionCode()
-            def versionName = extension.getVersion().versionName()
+            def versionName = extension.getVersion().versionNameForFlavor(flavor)
             variant.mergedFlavor.versionCode = versionCode
             variant.mergedFlavor.versionName = versionName
         }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -36,6 +36,15 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
         project.afterEvaluate {
             extension = project.androidAutoVersion
+
+            // Check extension properties
+            if (extension.releaseTask == null) {
+                throw new IllegalArgumentException("releaseTask must be defined for androidAutoVersion.")
+            }
+            if (extension.versionFile == null) {
+                throw new IllegalArgumentException("versionFile must be defined for androidAutoVersion.")
+            }
+
             applyVersion(project, extension.getVersion())
             makeReleaseTasks(project)
         }
@@ -70,9 +79,9 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
         def dependencies = [prepTask.name]
 
         if (flavor == VersionFlavor.RELEASE) {
-            def releaseTask = "assembleRelease"
+            def releaseTask = extension.releaseTask
             dependencies.add(releaseTask)
-            def task = project.getTasks().getByName("assembleRelease")
+            def task = project.getTasks().getByName(releaseTask)
             task.mustRunAfter(prepTask)
         }
         if (flavor == VersionFlavor.BETA) {
@@ -142,10 +151,10 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
         return newVersion;
     }
 
-    private static def applyVersion(Project project, Version version) {
+    private def applyVersion(Project project) {
         project.android.applicationVariants.all { variant ->
-            def versionCode = version.versionCode()
-            def versionName = version.versionName()
+            def versionCode = extension.getVersion().versionCode()
+            def versionName = extension.getVersion().versionName()
             variant.mergedFlavor.versionCode = versionCode
             variant.mergedFlavor.versionName = versionName
         }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -20,9 +20,6 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
     private enum VersionFlavor {
         RELEASE("Release"), BETA("Beta")
-        static def all() {
-            return [RELEASE, BETA]
-        }
 
         private final String name;
 
@@ -46,7 +43,11 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
     private def makeReleaseTasks(Project project) {
         def types = VersionType.all()
-        def flavors = VersionFlavor.all()
+        def flavors = [VersionFlavor.RELEASE]
+
+        if (extension.betaReleaseTask != null) {
+            flavors.add(VersionFlavor.BETA)
+        }
 
         def tasks = []
         for (def flavor in flavors) {

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -45,7 +45,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
                 throw new IllegalArgumentException("versionFile must be defined for androidAutoVersion.")
             }
 
-            applyVersion(project, extension.getVersion())
+            applyVersion(project)
             makeReleaseTasks(project)
         }
     }
@@ -110,7 +110,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             extension.saveVersion(version)
 
             // Apply to all variants
-            applyVersion(project, version)
+            applyVersion(project)
 
             def git = Grgit.open(project.rootDir)
 
@@ -130,7 +130,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             }
         }
     }
-    
+
     private def applyVersion(Project project) {
         project.android.applicationVariants.all { variant ->
             def versionCode = extension.getVersion().versionCode()

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -32,8 +32,16 @@ class Version {
         return formatter.call(major, minor, patch, buildNumber)
     }
 
+    String betaVersionName() {
+        return "$versionName()-beta"
+    }
+
     int versionCode() {
         return buildNumber;
+    }
+
+    String toJson() {
+        return "{\"major\": $major, \"minor\": $minor, \"patch\": $patch, \"buildNumber\": $buildNumber}"
     }
 
     @Override

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -69,6 +69,7 @@ class Version {
 
     void update(AndroidAutoVersionPlugin.VersionType type) {
         buildNumber += 1
+        revision += 1
         switch (type) {
             case MAJOR:
                 revision = 0

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -50,7 +50,7 @@ class Version {
     }
 
     String toJson() {
-        return "{\"major\": $major, \"minor\": $minor, \"patch\": $patch, \"buildNumber\": $buildNumber}"
+        return "{\"major\": $major, \"minor\": $minor, \"patch\": $patch, \"revision\": $revision, \"buildNumber\": $buildNumber}"
     }
 
     void update(AndroidAutoVersionPlugin.VersionType type) {

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -51,11 +51,11 @@ class Version {
     }
 
     String toJson() {
-        return JsonOutput.toJson([major: $major,
-                                  minor: $minor,
-                                  patch: $patch,
-                                  revision: $revision,
-                                  buildNumber: $buildNumber])
+        return JsonOutput.toJson([major: major,
+                                  minor: minor,
+                                  patch: patch,
+                                  revision: revision,
+                                  buildNumber: buildNumber])
     }
 
     void update(AndroidAutoVersionPlugin.VersionType type) {

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -2,6 +2,10 @@ package com.github.alexfu
 
 import groovy.json.internal.LazyMap
 
+import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.MAJOR
+import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.MINOR
+import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.PATCH
+
 class Version {
     int buildNumber = 0;
     int patch = 0;
@@ -42,6 +46,24 @@ class Version {
 
     String toJson() {
         return "{\"major\": $major, \"minor\": $minor, \"patch\": $patch, \"buildNumber\": $buildNumber}"
+    }
+
+    void update(AndroidAutoVersionPlugin.VersionType type) {
+        buildNumber += 1
+        switch (type) {
+            case MAJOR:
+                patch = 0
+                minor = 0
+                major += 1
+                break;
+            case MINOR:
+                patch = 0
+                minor += 1
+                break;
+            case PATCH:
+                patch += 1
+                break;
+        }
     }
 
     @Override

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -11,6 +11,7 @@ class Version {
     int patch = 0;
     int minor = 0;
     int major = 0;
+    int revision = 0;
     Closure<String> formatter;
 
     Version(Version source) {
@@ -18,6 +19,7 @@ class Version {
         patch = source.patch;
         minor = source.minor;
         major = source.major;
+        revision = source.revision;
         formatter = source.formatter;
     }
 
@@ -26,18 +28,19 @@ class Version {
         patch = source.patch;
         minor = source.minor;
         major = source.major;
+        revision = source.revision;
         this.formatter = formatter;
     }
 
     String versionName() {
         if (formatter == null) {
-            return "${major}.${minor}.${patch}"
+            return applyRevision("${major}.${minor}.${patch}")
         }
-        return formatter.call(major, minor, patch, buildNumber)
+        return applyRevision(formatter.call(major, minor, patch, buildNumber))
     }
 
     String betaVersionName() {
-        return "$versionName()-beta"
+        return applyRevision("$versionName()-beta")
     }
 
     int versionCode() {
@@ -52,15 +55,18 @@ class Version {
         buildNumber += 1
         switch (type) {
             case MAJOR:
+                revision = 0
                 patch = 0
                 minor = 0
                 major += 1
                 break;
             case MINOR:
+                revision = 0
                 patch = 0
                 minor += 1
                 break;
             case PATCH:
+                revision = 0
                 patch += 1
                 break;
         }
@@ -69,5 +75,10 @@ class Version {
     @Override
     String toString() {
         return versionName();
+    }
+
+    private String applyRevision(String name) {
+        if (revision == 0) return name
+        return "$name.$revision"
     }
 }

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -3,9 +3,7 @@ package com.github.alexfu
 import groovy.json.JsonOutput
 import groovy.json.internal.LazyMap
 
-import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.MAJOR
-import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.MINOR
-import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.PATCH
+import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.*
 
 class Version {
     int buildNumber = 0;
@@ -35,14 +33,25 @@ class Version {
         this.formatter = formatter;
     }
 
-    String versionName() {
+    private String versionName() {
         if (formatter == null) {
-            return applyRevision("${major}.${minor}.${patch}")
+            return "${major}.${minor}.${patch}"
         }
-        return applyRevision(formatter.call(major, minor, patch, buildNumber))
+        return formatter.call(major, minor, patch, buildNumber)
     }
 
-    String betaVersionName() {
+    String versionNameForFlavor(AndroidAutoVersionPlugin.VersionFlavor flavor) {
+        if (flavor == AndroidAutoVersionPlugin.VersionFlavor.BETA) {
+            return betaVersionName()
+        }
+        return releaseVersionName()
+    }
+
+    private String releaseVersionName() {
+        return applyRevision(versionName())
+    }
+
+    private String betaVersionName() {
         return applyRevision("${versionName()}-beta")
     }
 

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -1,5 +1,6 @@
 package com.github.alexfu
 
+import groovy.json.JsonOutput
 import groovy.json.internal.LazyMap
 
 import static com.github.alexfu.AndroidAutoVersionPlugin.VersionType.MAJOR
@@ -50,7 +51,11 @@ class Version {
     }
 
     String toJson() {
-        return "{\"major\": $major, \"minor\": $minor, \"patch\": $patch, \"revision\": $revision, \"buildNumber\": $buildNumber}"
+        return JsonOutput.toJson([major: $major,
+                                  minor: $minor,
+                                  patch: $patch,
+                                  revision: $revision,
+                                  buildNumber: $buildNumber])
     }
 
     void update(AndroidAutoVersionPlugin.VersionType type) {

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -28,7 +28,9 @@ class Version {
         patch = source.patch;
         minor = source.minor;
         major = source.major;
-        revision = source.revision;
+        if (source.revision) {
+            revision = source.revision;
+        }
         this.formatter = formatter;
     }
 

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -43,7 +43,7 @@ class Version {
     }
 
     String betaVersionName() {
-        return applyRevision("$versionName()-beta")
+        return applyRevision("${versionName()}-beta")
     }
 
     int versionCode() {

--- a/src/main/groovy/com/github/alexfu/Version.groovy
+++ b/src/main/groovy/com/github/alexfu/Version.groovy
@@ -10,7 +10,7 @@ class Version {
     int patch = 0;
     int minor = 0;
     int major = 0;
-    int revision = 0;
+    int revision = 1;
     Closure<String> formatter;
 
     Version(Version source) {
@@ -18,7 +18,7 @@ class Version {
         patch = source.patch;
         minor = source.minor;
         major = source.major;
-        revision = source.revision;
+        revision = Math.max(1, source.revision);
         formatter = source.formatter;
     }
 
@@ -28,7 +28,7 @@ class Version {
         minor = source.minor;
         major = source.major;
         if (source.revision) {
-            revision = source.revision;
+            revision = Math.max(1, source.revision);
         }
         this.formatter = formatter;
     }
@@ -95,7 +95,7 @@ class Version {
     }
 
     private String applyRevision(String name) {
-        if (revision == 0) return name
-        return "$name.$revision"
+        if (revision == 1) return name
+        return "$name.${revision-1}"
     }
 }


### PR DESCRIPTION
**New**:
- Releasing beta builds. To enable this, provide a `betaReleaseTask` property in your `androidAutoVersion` config block. For example:

```
androidAutoVersion {
  versionFile file("${project.rootDir}/config/version")
  releaseTask "assembleRelease"
  betaReleaseTask "assembleBetaRelease"
}
```
- Releasing revisions. A new `revision` property is now supported in your version file. The `revision` number always starts at 1. For example:

```
{
  "buildNumber": 99,
  "major": 1,
  "minor": 0,
  "patch": 1,
  "revision": 1
}
```

To support this, two new tasks have been added: `release` and `releaseBeta`. These new tasks will release your app and only increment the `revision` number. If you run `release` or `releaseBeta` when `revision > 1` then the expected `versionName` will have `revision - 1` appended to it with a period (i.e. given major = 1, minor = 2, patch = 3, revision = 22; `1.2.3.21`). The minus 1 is because revision 1 is simply the version name without the revision metadata appended to it.

**Changes**:
- `androidAutoVersion` config block now requires a `releaseTask` property. For example:

```
androidAutoVersion {
  versionFile file("${project.rootDir}/config/version")
  releaseTask "assembleRelease"
}
```
