### PR TITLE
Post hooks

### DIFF
--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -5,8 +5,9 @@ import org.gradle.api.Nullable
 class AndroidAutoVersionExtension {
     File versionFile
     String releaseTask
+    @Nullable String betaReleaseTask
     Closure<String> versionFormatter = { int major, int minor, int patch, int buildNumber ->
         return "${major}.${minor}.${patch}"
     }
-    @Nullable String betaReleaseTask
+    Closure[] postHooks = new Closure[0]
 }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -79,7 +79,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
         task.doLast {
             extension.postHooks.each { hook ->
-                hook()
+                hook(version.versionNameForFlavor(flavor))
             }
         }
 


### PR DESCRIPTION
Adds support for post hooks. This will allow users to perform side effects after the release task has been executed. 

**Example:**
```
androidAutoVersion {
    postHooks = [{ versionString ->
        exec {
            commandLine = ["echo", versionString]
        }
    }]
}
```

The `postHook` value expects an array of closures with a single argument. The argument is the version string (output of version formatter).