### PR TITLE
FlavorConfig

### DIFF
--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -1,14 +1,25 @@
 package com.github.alexfu
 
+import org.gradle.api.Action
 import org.gradle.api.Nullable
 
 class AndroidAutoVersionExtension {
     File versionFile = new File("version")
     String releaseTask
-    @Nullable String betaReleaseTask
     Closure<String> versionFormatter = { int major, int minor, int patch, int buildNumber ->
         return "${major}.${minor}.${patch}"
     }
     Closure[] postHooks = new Closure[0]
-    Closure[] betaPostHooks = new Closure[0]
+    @Nullable private FlavorConfig betaConfig
+
+    def beta(Action<FlavorConfig> action) {
+        if (betaConfig == null) {
+            betaConfig = new FlavorConfig()
+        }
+        action.execute(betaConfig)
+    }
+
+    @Nullable FlavorConfig betaConfig() {
+        return betaConfig
+    }
 }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -8,6 +8,7 @@ class AndroidAutoVersionExtension {
     Closure<String> versionFormatter = { int major, int minor, int patch, int buildNumber ->
         return "${major}.${minor}.${patch}"
     }
+    Closure[] postHooks = new Closure[0]
     private final FlavorConfig releaseConfig = new FlavorConfig()
     @Nullable private FlavorConfig betaConfig
 

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -10,4 +10,5 @@ class AndroidAutoVersionExtension {
         return "${major}.${minor}.${patch}"
     }
     Closure[] postHooks = new Closure[0]
+    Closure[] betaPostHooks = new Closure[0]
 }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionExtension.groovy
@@ -5,18 +5,25 @@ import org.gradle.api.Nullable
 
 class AndroidAutoVersionExtension {
     File versionFile = new File("version")
-    String releaseTask
     Closure<String> versionFormatter = { int major, int minor, int patch, int buildNumber ->
         return "${major}.${minor}.${patch}"
     }
-    Closure[] postHooks = new Closure[0]
+    private final FlavorConfig releaseConfig = new FlavorConfig()
     @Nullable private FlavorConfig betaConfig
+
+    def release(Action<FlavorConfig> action) {
+        action.execute(releaseConfig)
+    }
 
     def beta(Action<FlavorConfig> action) {
         if (betaConfig == null) {
             betaConfig = new FlavorConfig()
         }
         action.execute(betaConfig)
+    }
+
+    FlavorConfig releaseConfig() {
+        return releaseConfig
     }
 
     @Nullable FlavorConfig betaConfig() {

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -88,6 +88,12 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             extension.postHooks.each { hook ->
                 hook(versionString)
             }
+
+            if (flavor == VersionFlavor.BETA) {
+                extension.betaPostHooks.each { hook ->
+                    hook(versionString)
+                }
+            }
         }
 
         return task

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -38,7 +38,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
         def types = VersionType.all()
         def flavors = [VersionFlavor.RELEASE]
 
-        if (extension.betaReleaseTask != null) {
+        if (extension.betaConfig() != null) {
             flavors.add(VersionFlavor.BETA)
         }
 
@@ -68,7 +68,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
         if (flavor == VersionFlavor.RELEASE) {
             releaseTask = project.getTasks().findByName(extension.releaseTask)
         } else if (flavor == VersionFlavor.BETA) {
-            releaseTask = project.getTasks().findByName(extension.betaReleaseTask)
+            releaseTask = project.getTasks().findByName(extension.betaConfig().releaseTask)
         }
 
         if (releaseTask == null) {
@@ -89,8 +89,8 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
                 hook(versionString)
             }
 
-            if (flavor == VersionFlavor.BETA) {
-                extension.betaPostHooks.each { hook ->
+            if (extension.betaConfig() != null) {
+                extension.betaConfig().postHooks.each { hook ->
                     hook(versionString)
                 }
             }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -90,8 +90,10 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
         task.doLast {
             def versionString = version.versionNameForFlavor(flavor)
-            releaseConfig.postHooks.each { hook ->
-                hook(versionString)
+            if (flavor == VersionFlavor.RELEASE) {
+                releaseConfig.postHooks.each { hook ->
+                    hook(versionString)
+                }
             }
 
             if (flavor == VersionFlavor.BETA && betaConfig != null) {

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -90,13 +90,17 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
         task.doLast {
             def versionString = version.versionNameForFlavor(flavor)
+
+            // Run global post hooks first
+            extension.postHooks.each { hook ->
+                hook(versionString)
+            }
+
             if (flavor == VersionFlavor.RELEASE) {
                 releaseConfig.postHooks.each { hook ->
                     hook(versionString)
                 }
-            }
-
-            if (flavor == VersionFlavor.BETA && betaConfig != null) {
+            } else if (flavor == VersionFlavor.BETA && betaConfig != null) {
                 betaConfig.postHooks.each { hook ->
                     hook(versionString)
                 }

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -15,8 +15,8 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             extension = project.androidAutoVersion
 
             // Check extension properties
-            if (extension.releaseTask == null) {
-                throw new IllegalArgumentException("releaseTask must be defined for androidAutoVersion.")
+            if (extension.releaseConfig() == null) {
+                throw new IllegalArgumentException("release config must be defined for androidAutoVersion.")
             }
             if (extension.versionFile == null) {
                 throw new IllegalArgumentException("versionFile must be defined for androidAutoVersion.")
@@ -66,7 +66,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
         def releaseTask = null
 
         if (flavor == VersionFlavor.RELEASE) {
-            releaseTask = project.getTasks().findByName(extension.releaseTask)
+            releaseTask = project.getTasks().findByName(extension.releaseConfig().releaseTask)
         } else if (flavor == VersionFlavor.BETA) {
             releaseTask = project.getTasks().findByName(extension.betaConfig().releaseTask)
         }
@@ -85,7 +85,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
 
         task.doLast {
             def versionString = version.versionNameForFlavor(flavor)
-            extension.postHooks.each { hook ->
+            extension.releaseConfig().postHooks.each { hook ->
                 hook(versionString)
             }
 

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -89,7 +89,7 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
                 hook(versionString)
             }
 
-            if (extension.betaConfig() != null) {
+            if (flavor == VersionFlavor.BETA && extension.betaConfig() != null) {
                 extension.betaConfig().postHooks.each { hook ->
                     hook(versionString)
                 }

--- a/src/main/groovy/com/github/alexfu/FlavorConfig.groovy
+++ b/src/main/groovy/com/github/alexfu/FlavorConfig.groovy
@@ -1,0 +1,6 @@
+package com.github.alexfu
+
+class FlavorConfig {
+    String releaseTask
+    Closure[] postHooks = new Closure[0]
+}

--- a/src/main/groovy/com/github/alexfu/VersionFlavor.groovy
+++ b/src/main/groovy/com/github/alexfu/VersionFlavor.groovy
@@ -3,7 +3,7 @@ package com.github.alexfu
 enum VersionFlavor {
     RELEASE("Release"), BETA("Beta")
 
-    private final String name
+    final String name
 
     private VersionFlavor(String name) {
         this.name = name

--- a/src/main/groovy/com/github/alexfu/VersionType.groovy
+++ b/src/main/groovy/com/github/alexfu/VersionType.groovy
@@ -7,7 +7,7 @@ enum VersionType {
         return [MAJOR, MINOR, PATCH, NONE]
     }
 
-    private final String name
+    final String name
 
     private VersionType(String name) {
         this.name = name


### PR DESCRIPTION
This PR will introduce a breaking API change. Namely, the way version flavors are handled.  This PR will make version flavor configurations be a part of their own config closure, i.e:

```
androidAutoVersion {
  release {
    releaseTask = "assembleRelease"
  }
  beta {
    releaseTask = "assembleRelease"
  }
}
```

Furthermore, post hooks are now configurable on a global and per flavor basis:

```
androidAutoVersion {
  postHooks = [] // Global post hooks; will run before release or beta post hooks.
  release {
    releaseTask = "assembleRelease"
    postHooks = []
  }
  beta {
    releaseTask = "assembleRelease"
    postHooks = []
  }
}
```

Fixes #24 