### PR TITLE
updated version reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ buildscript {
     maven { url 'https://jitpack.io' }
   }
   dependencies {
-    classpath 'com.github.alexfu:androidautoversion:2.0.0'
+    classpath 'com.github.alexfu:androidautoversion:$latest_version'
   }
 }
 ```
+
+Change `$latest_version` to the latest release version found [here](https://github.com/alexfu/androidautoversion/releases).
 
 ## Step 2
 Include the following in your app-level `build.gradle` file:


### PR DESCRIPTION
I had spent some time trying to track down a bug but then realized I had an outdated version of the plugin (`v2.0.0`) and instead I should have been using the latest version (`v2.0.2`) which fixed the bug I was experiencing. Therefore I added a variable to the gradle dependency step so that future users of the plugin are forced to go find the latest version and it also helps to reduce maintenance of this piece of the README.