### PR TITLE
Fix #32 Compatibility issue with Gradle 4.6

### DIFF
--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -66,10 +66,10 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
             int versionCode = version.versionCode
             String versionName = version.versionName
 
-            variant.mergedFlavor.versionCode = versionCode
-            variant.mergedFlavor.versionName = versionName
-
             variant.outputs.all { output ->
+                output.versionNameOverride = versionName
+                output.versionCodeOverride = versionCode
+
                 output.processManifest.doLast {
                     File manifestFile = new File("$manifestOutputDirectory/AndroidManifest.xml")
                     Node manifest = new XmlParser().parse(manifestFile)


### PR DESCRIPTION
Set versionCode and versionName not directly to mergedFlavor since this is not allowed in Gradle 4.6 and caused an sync error. 