### PR TITLE
Bugfix for Issue 34: Manifest file not found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,5 +36,5 @@ targetCompatibility = 1.7
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.2.1'
+    compile 'com.android.tools.build:gradle:3.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'java'
 apply plugin: 'groovy'
 
 group = 'com.github.alexfu'
-version = "3.0.1"
+version = "3.0.2"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
+++ b/src/main/groovy/com/github/alexfu/AndroidAutoVersionPlugin.groovy
@@ -73,7 +73,9 @@ class AndroidAutoVersionPlugin implements Plugin<Project> {
                 output.versionCodeOverride = versionCode
 
                 output.processManifest.doLast {
-                    File manifestFile = new File("$manifestOutputDirectory/AndroidManifest.xml")
+                    File manifestFile = new File(
+                        output.processManifest.manifestOutputDirectory.get().asFile,
+                        "AndroidManifest.xml")
                     Node manifest = new XmlParser().parse(manifestFile)
                     Namespace ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
 


### PR DESCRIPTION
Fixes [Issue 34](https://github.com/alexfu/androidautoversion/issues/34) 🥳

✅Tested manually from plugin installed in local maven. It allows building Android Projects with this androidversionplugin and following configuration:

- Android Studio 3.4 (official stable at the moment)
- Android Gradle Plugin (in build.gradle) ⇢ 'com.android.tools.build:gradle:3.4.0'
- Gradle (in gradle/wrapper/gradle-wrapper.properties)⇢ Version 5.1.1

